### PR TITLE
Agraph refactor

### DIFF
--- a/bingo/Base/Chromosome.py
+++ b/bingo/Base/Chromosome.py
@@ -25,9 +25,9 @@ class Chromosome(metaclass=ABCMeta):
               Whether the fitness has been calculated for the individual
     """
     def __init__(self, genetic_age=0, fitness=None, fit_set=False):
-        self.genetic_age = genetic_age
+        self._genetic_age = genetic_age
         self._fitness = fitness
-        self.fit_set = fit_set
+        self._fit_set = fit_set
 
     @property
     def fitness(self):
@@ -37,7 +37,23 @@ class Chromosome(metaclass=ABCMeta):
     @fitness.setter
     def fitness(self, fitness):
         self._fitness = fitness
-        self.fit_set = True
+        self._fit_set = True
+
+    @property
+    def genetic_age(self):
+        return self._genetic_age
+
+    @genetic_age.setter
+    def genetic_age(self, genetic_age):
+        self._genetic_age = genetic_age
+
+    @property
+    def fit_set(self):
+        return self._fit_set
+
+    @fit_set.setter
+    def fit_set(self, fit_set):
+        self._fit_set = fit_set
 
     def copy(self):
         """copy

--- a/tests/AGraph/conftest.py
+++ b/tests/AGraph/conftest.py
@@ -6,6 +6,10 @@ import pytest
 from bingo.SymbolicRegression.AGraph.AGraph import AGraph
 from bingo.SymbolicRegression.AGraph.ComponentGenerator import ComponentGenerator
 
+try:
+    from bingocpp.build import bingocpp as bingocpp
+except ImportError:
+    bingocpp = None
 
 @pytest.fixture
 def sample_component_generator():
@@ -16,7 +20,6 @@ def sample_component_generator():
     generator.add_operator(2)
     generator.add_operator(6)
     return generator
-
 
 @pytest.fixture
 def sample_agraph_1():
@@ -32,10 +35,56 @@ def sample_agraph_1():
     test_graph.fitness = 1
     return test_graph
 
+@pytest.fixture
+def sample_agraph_1_cpp():
+    if bingocpp == None:
+        return None
+    test_graph = bingocpp.AGraph()
+    test_graph.command_array = np.array([[0, 0, 0],  # sin(X_0 + 1.0) + 1.0
+                                         [1, 0, 0],
+                                         [2, 0, 1],
+                                         [6, 2, 2],
+                                         [2, 0, 1],
+                                         [2, 3, 1]])
+    test_graph.genetic_age = 10
+    test_graph.set_local_optimization_params([1.0, ])
+    test_graph.fitness = 1
+    return test_graph
+
+def _set_sample_agraph_1_data(test_graph):
+    test_graph.command_array = np.array([[0, 0, 0],  # sin(X_0 + 1.0) + 1.0
+                                         [1, 0, 0],
+                                         [2, 0, 1],
+                                         [6, 2, 2],
+                                         [2, 0, 1],
+                                         [2, 3, 1]])
+    test_graph.genetic_age = 10
+    test_graph.set_local_optimization_params([1.0, ])
+    test_graph.fitness = 1
+
+@pytest.fixture(params=["python",
+                        pytest.param("cpp",
+                                marks=pytest.mark.skipif(
+                                    not bingocpp,
+                                    reason='BingoCpp import failure'))])
+def sample_agraph_1_list(request, sample_agraph_1, sample_agraph_1_cpp):
+    if request.param == "python":
+        return sample_agraph_1
+    return sample_agraph_1_cpp
 
 @pytest.fixture
 def sample_agraph_2():
     test_graph = AGraph()
+    return _set_sample_agraph_2_data(test_graph)
+
+@pytest.fixture
+def sample_agraph_2_cpp():
+    if bingocpp == None:
+        return None
+    test_graph = bingocpp.AGraph()
+    return _set_sample_agraph_2_data(test_graph)
+
+def _set_sample_agraph_2_data(test_graph):
     test_graph.command_array = np.array([[0, 1, 3],  # sin((c_1-c_1)*X_1)
                                          [1, 1, 1],
                                          [3, 1, 1],
@@ -46,3 +95,4 @@ def sample_agraph_2():
     test_graph.set_local_optimization_params([1.0])
     test_graph.fitness = 2
     return test_graph
+

--- a/tests/SymbolicRegression/Benchmarking/test_benchmark_test.py
+++ b/tests/SymbolicRegression/Benchmarking/test_benchmark_test.py
@@ -9,7 +9,9 @@ from bingo.SymbolicRegression.AGraph.AGraph import AGraph
 
 
 def dummy_train_function(training_data):
-    return AGraph(fitness=1.5), None
+    dummy_train_graph = AGraph()
+    dummy_train_graph.fitness = 1.5
+    return dummy_train_graph, None
 
 
 def dummy_metric_function(equation, data, aux_info):


### PR DESCRIPTION
This PR contains modification to the AGraph as to create easy bindings for pybind that will allow a similar interface. Tests are modified to use the AGraph defined in python and the one defined in C++.