### PR TITLE
Cont local opt benchmarks

### DIFF
--- a/tests/continous_local_opt_benchmarks.py
+++ b/tests/continous_local_opt_benchmarks.py
@@ -9,11 +9,16 @@ from bingo.local_optimizers.continuous_local_opt \
     import ContinuousLocalOptimization
 from bingocpp.build import bingocpp as cppBackend
 
+from tests.benchmark_data import StatsPrinter, \
+    generate_random_individuals, \
+    copy_to_cpp, \
+    TEST_EXPLICIT_REGRESSION, \
+    TEST_EXPLICIT_REGRESSION_CPP, \
+    TEST_IMPLICIT_REGRESSION, \
+    TEST_IMPLICIT_REGRESSION_CPP
 
-from tests.benchmark_data import StatsPrinter, TEST_AGRAPHS, TEST_AGRAPHS_CPP
-from tests.fitness_benchmark import TEST_EXPLICIT_REGRESSION, \
-                                    TEST_EXPLICIT_REGRESSION_CPP, \
-                                    TEST_IMPLICIT_REGRESSION, TEST_IMPLICIT_REGRESSION_CPP
+import tests.benchmark_data as benchmark_data
+
 
 TEST_EXPLICIT_REGRESSION_OPTIMIZATION \
     = ContinuousLocalOptimization(TEST_EXPLICIT_REGRESSION)
@@ -25,53 +30,70 @@ TEST_IMPLICIT_REGRESSION_OPTIMIZATION_CPP \
     = ContinuousLocalOptimization(TEST_IMPLICIT_REGRESSION_CPP)
 
 
-TEST_AGRAPH_LISTS = []
-TEST_AGRAPH_LISTS_CPP = []
+TEST_ITERATION = 0
+DEBUG = False
+TEST_AGRAPHS = generate_random_individuals(benchmark_data.NUM_AGRAPHS_INDVS,
+                                           benchmark_data.COMMAND_ARRAY_SIZE,
+                                           True)
+TEST_AGRAPHS_CPP = copy_to_cpp(TEST_AGRAPHS)
+BENCHMARK_LISTS = []
+BENCHMARK_LISTS_CPP = []
 
 
 def benchmark_explicit_regression_with_optimization():
-    for test_run in TEST_AGRAPH_LISTS:
+    for i, test_run in enumerate(BENCHMARK_LISTS):
         for indv in test_run:
             _ = TEST_EXPLICIT_REGRESSION_OPTIMIZATION.__call__(indv)
 
 
 def benchmark_explicit_regression_cpp_with_optimization():
-    for test_run in TEST_AGRAPH_LISTS_CPP:
+    for i, test_run in enumerate(BENCHMARK_LISTS_CPP):
         for indv in test_run:
             _ = TEST_EXPLICIT_REGRESSION_OPTIMIZATION_CPP.__call__(indv)
 
 
 def benchmark_implicit_regression_with_optimization():
-    for test_run in TEST_AGRAPH_LISTS:
+    for i, test_run in enumerate(BENCHMARK_LISTS):
         for indv in test_run:
-            _ = TEST_IMPLICIT_REGRESSION.__call__(indv)
+            _ = TEST_IMPLICIT_REGRESSION_OPTIMIZATION.__call__(indv)
 
 
 def benchmark_implicit_regression_cpp_with_optimization():
-    for test_run in TEST_AGRAPH_LISTS_CPP:
+    for i, test_run in enumerate(BENCHMARK_LISTS_CPP):
         for indv in test_run:
-            _ = TEST_IMPLICIT_REGRESSION_CPP.__call__(indv)
+            _ = TEST_IMPLICIT_REGRESSION_OPTIMIZATION_CPP.__call__(indv)
 
 
 def reset_test_data():
-    TEST_AGRAPH_LISTS.clear()
-    for num_runs in range(0, 100):
-        run_list = []
-        for agraph in TEST_AGRAPHS:
-            run_list.append(agraph.copy())
-        TEST_AGRAPH_LISTS.append(run_list)
+    _reset_test_data_helper(TEST_AGRAPHS, BENCHMARK_LISTS)
 
 
 def reset_test_data_cpp():
-    TEST_AGRAPH_LISTS_CPP.clear()
-    for num_runs in range(0, 100):
+    _reset_test_data_helper(TEST_AGRAPHS_CPP, BENCHMARK_LISTS_CPP)
+
+
+def _reset_test_data_helper(agraph_list, benchmarking_array):
+    global TEST_ITERATION
+    if DEBUG:
+        print("...Executing iteration:", TEST_ITERATION)
+    _create_fresh_benchmarking_array(agraph_list, benchmarking_array)
+    TEST_ITERATION += 1
+
+
+def _create_fresh_benchmarking_array(agraph_list, benchmarking_array):
+    benchmarking_array.clear()
+    for num_runs in range(0, benchmark_data.BENCHMARK_EVALUATION_COUNT):
         run_list = []
-        for agraph in TEST_AGRAPHS_CPP:
+        for agraph in agraph_list:
             run_list.append(agraph.copy())
-        TEST_AGRAPH_LISTS_CPP.append(run_list)
+        benchmarking_array.append(run_list)
 
 
-def do_benchmarking():
+def do_benchmarking(debug = False):
+    if debug:
+        global DEBUG
+        DEBUG = True
+
     benchmarks = [
         [benchmark_explicit_regression_with_optimization,
          benchmark_explicit_regression_cpp_with_optimization,
@@ -92,12 +114,38 @@ def do_benchmarking():
 def _run_benchmarks(printer, regression, regression_cpp):
     for backend, name in [[pyBackend, " py"], [cppBackend, "c++"]]:
         agraph_module.Backend = backend
-        printer.add_stats("py:  fitness " +name + ": evaluate ",
-                          timeit.repeat(regression, setup=reset_test_data,
-                                        number=1, repeat=10))
-    printer.add_stats("c++: fitness c++: evaluate ",
-                      timeit.repeat(regression_cpp, setup=reset_test_data_cpp,
-                                    number=1, repeat=10))
+        _add_stats_and_log_intermediate_steps(
+            printer,
+            regression,
+            "py:  fitness " +name + ": evaluate ",
+            reset_test_data
+        )
+    _add_stats_and_log_intermediate_steps(
+        printer,
+        regression_cpp,
+        "c++: fitness c++: evaluate ",
+        reset_test_data_cpp
+    )
+
+def _add_stats_and_log_intermediate_steps(stats_printer,
+                                          regression, 
+                                          run_name,
+                                          setup_function):
+    if DEBUG:
+        print("Running", regression.__name__, "...................")
+    stats_printer.add_stats(
+        run_name,
+        timeit.repeat(regression, setup=setup_function, number=1,
+                      repeat=benchmark_data.BENCHMARK_DATA_POINTS)
+    )
+    if DEBUG:
+        print(regression.__name__, "finished\n")
+    _reset_iteration_count()
+
+
+def _reset_iteration_count():
+    global TEST_ITERATION
+    TEST_ITERATION = 0
 
 
 def _print_stats(printer_list):

--- a/tests/continous_local_opt_benchmarks.py
+++ b/tests/continous_local_opt_benchmarks.py
@@ -82,7 +82,7 @@ def _reset_test_data_helper(agraph_list, benchmarking_array):
 
 def _create_fresh_benchmarking_array(agraph_list, benchmarking_array):
     benchmarking_array.clear()
-    for num_runs in range(0, benchmark_data.BENCHMARK_EVALUATION_COUNT):
+    for num_runs in range(0, 10):
         run_list = []
         for agraph in agraph_list:
             run_list.append(agraph.copy())
@@ -154,4 +154,4 @@ def _print_stats(printer_list):
 
 
 if __name__ == '__main__':
-    do_benchmarking()
+    do_benchmarking(True)

--- a/tests/continous_local_opt_benchmarks.py
+++ b/tests/continous_local_opt_benchmarks.py
@@ -108,7 +108,7 @@ def do_benchmarking(debug = False):
         _run_benchmarks(printer, regression, regression_cpp)
         stats_printer_list.append(printer)
 
-    _print_stats(stats_printer_list)
+    return stats_printer_list
 
 
 def _run_benchmarks(printer, regression, regression_cpp):

--- a/tests/continous_local_opt_benchmarks.py
+++ b/tests/continous_local_opt_benchmarks.py
@@ -1,0 +1,109 @@
+import timeit
+
+import numpy as np
+
+from bingo.symbolic_regression.agraph \
+    import agraph as agraph_module, backend as pyBackend
+from bingo.symbolic_regression.agraph.agraph import AGraph
+from bingo.local_optimizers.continuous_local_opt \
+    import ContinuousLocalOptimization
+from bingocpp.build import bingocpp as cppBackend
+
+
+from tests.benchmark_data import StatsPrinter, TEST_AGRAPHS, TEST_AGRAPHS_CPP
+from tests.fitness_benchmark import TEST_EXPLICIT_REGRESSION, \
+                                    TEST_EXPLICIT_REGRESSION_CPP, \
+                                    TEST_IMPLICIT_REGRESSION, TEST_IMPLICIT_REGRESSION_CPP
+
+TEST_EXPLICIT_REGRESSION_OPTIMIZATION \
+    = ContinuousLocalOptimization(TEST_EXPLICIT_REGRESSION)
+TEST_IMPLICIT_REGRESSION_OPTIMIZATION \
+    = ContinuousLocalOptimization(TEST_IMPLICIT_REGRESSION)
+TEST_EXPLICIT_REGRESSION_OPTIMIZATION_CPP \
+    = ContinuousLocalOptimization(TEST_EXPLICIT_REGRESSION_CPP)
+TEST_IMPLICIT_REGRESSION_OPTIMIZATION_CPP \
+    = ContinuousLocalOptimization(TEST_IMPLICIT_REGRESSION_CPP)
+
+
+TEST_AGRAPH_LISTS = []
+TEST_AGRAPH_LISTS_CPP = []
+
+
+def benchmark_explicit_regression_with_optimization():
+    for test_run in TEST_AGRAPH_LISTS:
+        for indv in test_run:
+            _ = TEST_EXPLICIT_REGRESSION_OPTIMIZATION.__call__(indv)
+
+
+def benchmark_explicit_regression_cpp_with_optimization():
+    for test_run in TEST_AGRAPH_LISTS_CPP:
+        for indv in test_run:
+            _ = TEST_EXPLICIT_REGRESSION_OPTIMIZATION_CPP.__call__(indv)
+
+
+def benchmark_implicit_regression_with_optimization():
+    for test_run in TEST_AGRAPH_LISTS:
+        for indv in test_run:
+            _ = TEST_IMPLICIT_REGRESSION.__call__(indv)
+
+
+def benchmark_implicit_regression_cpp_with_optimization():
+    for test_run in TEST_AGRAPH_LISTS_CPP:
+        for indv in test_run:
+            _ = TEST_IMPLICIT_REGRESSION_CPP.__call__(indv)
+
+
+def reset_test_data():
+    TEST_AGRAPH_LISTS.clear()
+    for num_runs in range(0, 100):
+        run_list = []
+        for agraph in TEST_AGRAPHS:
+            run_list.append(agraph.copy())
+        TEST_AGRAPH_LISTS.append(run_list)
+
+
+def reset_test_data_cpp():
+    TEST_AGRAPH_LISTS_CPP.clear()
+    for num_runs in range(0, 100):
+        run_list = []
+        for agraph in TEST_AGRAPHS_CPP:
+            run_list.append(agraph.copy())
+        TEST_AGRAPH_LISTS_CPP.append(run_list)
+
+
+def do_benchmarking():
+    benchmarks = [
+        [benchmark_explicit_regression_with_optimization,
+         benchmark_explicit_regression_cpp_with_optimization,
+         "LOCAL OPTIMIZATION: EXPLICIT REGRESSION BENCHMARKS"], 
+        [benchmark_implicit_regression_with_optimization, 
+         benchmark_implicit_regression_cpp_with_optimization,
+         "LOCAL OPTIMIZATION: IMPLICIT REGRESSION BENCHMARKS"]]
+
+    stats_printer_list = []
+    for regression, regression_cpp, reg_name in benchmarks:
+        printer = StatsPrinter(reg_name)
+        _run_benchmarks(printer, regression, regression_cpp)
+        stats_printer_list.append(printer)
+
+    _print_stats(stats_printer_list)
+
+
+def _run_benchmarks(printer, regression, regression_cpp):
+    for backend, name in [[pyBackend, " py"], [cppBackend, "c++"]]:
+        agraph_module.Backend = backend
+        printer.add_stats("py:  fitness " +name + ": evaluate ",
+                          timeit.repeat(regression, setup=reset_test_data,
+                                        number=1, repeat=10))
+    printer.add_stats("c++: fitness c++: evaluate ",
+                      timeit.repeat(regression_cpp, setup=reset_test_data_cpp,
+                                    number=1, repeat=10))
+
+
+def _print_stats(printer_list):
+    for printer in printer_list:
+        printer.print()
+
+
+if __name__ == '__main__':
+    do_benchmarking()

--- a/tests/evaluation_benchmark.py
+++ b/tests/evaluation_benchmark.py
@@ -37,4 +37,4 @@ def do_benchmarking():
         printer.add_stats(name + ": c derivative",
                           timeit.repeat(benchmark_evaluate_w_c_derivative,
                                         number=100, repeat=10))
-    printer.print()
+    return printer

--- a/tests/fitness_benchmark.py
+++ b/tests/fitness_benchmark.py
@@ -4,14 +4,19 @@ import numpy as np
 
 from bingo.symbolic_regression.agraph \
     import agraph as agraph_module, backend as pyBackend
-from bingo.symbolic_regression.implicit_regression \
-    import ImplicitRegression, ImplicitTrainingData, calculate_partials
-from bingo.symbolic_regression.explicit_regression \
-    import ExplicitRegression, ExplicitTrainingData
 from bingocpp.build import bingocpp as cppBackend
 
 import tests.benchmark_data as benchmark_data
-from tests.benchmark_data import TEST_AGRAPHS, TEST_X, TEST_AGRAPHS_CPP
+from tests.benchmark_data import \
+    TEST_AGRAPHS, \
+    TEST_AGRAPHS_CPP, \
+    TEST_X_PARTIALS, \
+    TEST_Y_ZEROS, \
+    TEST_DX_DT, \
+    TEST_EXPLICIT_REGRESSION, \
+    TEST_EXPLICIT_REGRESSION_CPP, \
+    TEST_IMPLICIT_REGRESSION, \
+    TEST_IMPLICIT_REGRESSION_CPP
 
 
 def benchmark_explicit_regression():
@@ -34,43 +39,6 @@ def benchmark_implicit_regression_cpp():
         _ = TEST_IMPLICIT_REGRESSION_CPP.__call__(indv)
 
 
-def _initialize_implicit_data():
-    x, dx_dt, _ = calculate_partials(TEST_X)
-    return x, dx_dt
-
-
-TEST_X_PARTIALS, TEST_DX_DT = _initialize_implicit_data()
-TEST_Y_ZEROS = np.zeros(TEST_X_PARTIALS.shape)
-
-
-def explicit_regression():
-    TEST_EXPLICIT_TRAINING_DATA \
-        = ExplicitTrainingData(TEST_X_PARTIALS, TEST_Y_ZEROS)
-    return ExplicitRegression(TEST_EXPLICIT_TRAINING_DATA)
-
-
-def explicit_regression_cpp():
-    training_data = cppBackend.ExplicitTrainingData(TEST_X_PARTIALS, TEST_Y_ZEROS)
-    return cppBackend.ExplicitRegression(training_data)
-
-
-def implicit_regression():
-    training_data = ImplicitTrainingData(TEST_X_PARTIALS, TEST_DX_DT)
-    return ImplicitRegression(training_data)
-
-
-def implicit_regression_cpp():
-    training_data = cppBackend.ImplicitTrainingData(TEST_X_PARTIALS, TEST_DX_DT)
-    return cppBackend.ImplicitRegression(training_data)
-
-
-TEST_EXPLICIT_REGRESSION = explicit_regression()
-TEST_EXPLICIT_REGRESSION_CPP = explicit_regression_cpp()
-
-TEST_IMPLICIT_REGRESSION = implicit_regression()
-TEST_IMPLICIT_REGRESSION_CPP = implicit_regression_cpp()
-
-
 def do_benchmarking():
     benchmarks = [
         [benchmark_explicit_regression, benchmark_explicit_regression_cpp,
@@ -90,12 +58,16 @@ def do_benchmarking():
 def _run_benchmarks(printer, regression, regression_cpp):
     for backend, name in [[pyBackend, " py"], [cppBackend, "c++"]]:
         agraph_module.Backend = backend
-        printer.add_stats("py:  fitness " +name + ": evaluate ",
-                          timeit.repeat(regression,
-                                        number=100, repeat=10))
-    printer.add_stats("c++: fitness c++: evaluate ",
-                          timeit.repeat(regression_cpp,
-                                        number=100, repeat=10))
+        printer.add_stats(
+            "py:  fitness " +name + ": evaluate ",
+             timeit.repeat(regression,
+                           number=benchmark_data.BENCHMARK_EVALUATION_COUNT,
+                           repeat=benchmark_data.BENCHMARK_DATA_POINTS))
+    printer.add_stats(
+        "c++: fitness c++: evaluate ",
+        timeit.repeat(regression_cpp,
+                      number=benchmark_data.BENCHMARK_EVALUATION_COUNT,
+                      repeat=benchmark_data.BENCHMARK_DATA_POINTS))
 
 
 def _print_stats(printer_list):

--- a/tests/fitness_benchmark.py
+++ b/tests/fitness_benchmark.py
@@ -52,7 +52,7 @@ def do_benchmarking():
         _run_benchmarks(printer, regression, regression_cpp)
         stats_printer_list.append(printer)
 
-    _print_stats(stats_printer_list)
+    return stats_printer_list
 
 
 def _run_benchmarks(printer, regression, regression_cpp):

--- a/tests/performance_benchmarks.py
+++ b/tests/performance_benchmarks.py
@@ -2,6 +2,11 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=missing-docstring
 import tests.evaluation_benchmark as evaluation_benchmark
+import tests.fitness_benchmark as fitness_benchmark
+import tests.continous_local_opt_benchmarks as clo_benchmark
 
 if __name__ == '__main__':
     evaluation_benchmark.do_benchmarking()
+    fitness_benchmark.do_benchmarking()
+    clo_benchmark.do_benchmarking(debug=True)
+

--- a/tests/performance_benchmarks.py
+++ b/tests/performance_benchmarks.py
@@ -5,9 +5,22 @@ import tests.evaluation_benchmark as evaluation_benchmark
 import tests.fitness_benchmark as fitness_benchmark
 import tests.continous_local_opt_benchmarks as clo_benchmark
 
+PROBLEM_SET_VERSION = 2
+
+
+def print_stats(printer_list):
+    for printer in printer_list:
+        printer.print()
+
+
 if __name__ == '__main__':
-    print("------------------USING AGRAPH PROBLEM SET # 2-----------------------")
-    evaluation_benchmark.do_benchmarking()
-    fitness_benchmark.do_benchmarking()
-    clo_benchmark.do_benchmarking(debug=True)
+    title = 'USING AGRAPH PROBLEM SET # '
+    title += str(PROBLEM_SET_VERSION)
+    num_stars_left_side = int((80 - len(title))/2)
+    num_stars_right_side = int((80 - len(title) + 1) / 2)
+    printer_list = [evaluation_benchmark.do_benchmarking()]
+    printer_list += fitness_benchmark.do_benchmarking()
+    printer_list += clo_benchmark.do_benchmarking(debug=True)
+    print('*'*num_stars_left_side + title + '*'*num_stars_right_side)
+    print_stats(printer_list)
 

--- a/tests/performance_benchmarks.py
+++ b/tests/performance_benchmarks.py
@@ -6,6 +6,7 @@ import tests.fitness_benchmark as fitness_benchmark
 import tests.continous_local_opt_benchmarks as clo_benchmark
 
 if __name__ == '__main__':
+    print("------------------USING AGRAPH PROBLEM SET # 2-----------------------")
     evaluation_benchmark.do_benchmarking()
     fitness_benchmark.do_benchmarking()
     clo_benchmark.do_benchmarking(debug=True)


### PR DESCRIPTION
This PR contains the following changes:
  -  All AGraph objects can be locally optimized
  -  fitness_benchmarks.py move regression objects to benchmark_data.py as module objects
  -  benchmark_data.py has default constant values that can be used easily throughout all benchmarks
  - continuous_local_opt_benchmarks.py contain benchmarks for local optimization on same data in fitness benchmarks.
  - logging is added to continous_local_opt_benchmarks.py to prevent timeout in travis build.
