### PR TITLE
Updated bingo to default to C++ bindings if modules are built correctly

### DIFF
--- a/.build_bingocpp.sh
+++ b/.build_bingocpp.sh
@@ -1,8 +1,3 @@
 cd bingocpp
-mkdir -p build
-cd build
-PYEXECUTABLE=`which python`
-cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE:FILEPATH=$PYEXECUTABLE ..
-make VERBOSE=1 -j
-make bingocpp
+./build.sh
 cd ../..

--- a/bingo/symbolic_regression/__init__.py
+++ b/bingo/symbolic_regression/__init__.py
@@ -1,0 +1,24 @@
+"""
+Import the core names of bingo symbolic_regression library
+
+Programs that want to build bingo symbolic regression apps
+without having to import specific modules can import this.
+"""
+
+from .agraph.component_generator import *
+from .agraph.crossover import *
+from .agraph.generator import *
+from .agraph.mutation import *
+from .atomic_potential_regression import *
+
+# Try to load in C++ cpython extensions
+# TODO: consider this init file but remove imports for python
+# that have C++ bindings
+try:
+    from bingocpp.build.symbolic_regression import *
+except Exception as e:
+    from .agraph.agraph import *
+    from .equation import *
+    from .explicit_regression import *
+    from .implicit_regression import *
+    print("Could not load C++ modules")

--- a/bingo/symbolic_regression/agraph/agraph.py
+++ b/bingo/symbolic_regression/agraph/agraph.py
@@ -49,12 +49,7 @@ import numpy as np
 from .maps import STACK_PRINT_MAP, LATEX_PRINT_MAP, CONSOLE_PRINT_MAP
 from ..equation import Equation
 from ...local_optimizers import continuous_local_opt
-
-try:
-    from bingocpp.build import bingocpp as Backend
-except ImportError as e:
-    print(e)
-    from . import backend as Backend
+from . import backend as Backend
 
 LOGGER = logging.getLogger(__name__)
 

--- a/bingo/symbolic_regression/agraph/generator.py
+++ b/bingo/symbolic_regression/agraph/generator.py
@@ -11,8 +11,10 @@ from .agraph import AGraph
 from ...chromosomes.generator import Generator
 from ...util.argument_validation import argument_validation
 
+# TODO: Remove after cpp agraph generator created. Import in
+# symbolic regression init file
 try:
-    from bingocpp.build import bingocpp as bingocpp
+    from bingocpp.build import symbolic_regression as bingocpp
 except ImportError:
     bingocpp = None
 

--- a/tests/agraph/conftest.py
+++ b/tests/agraph/conftest.py
@@ -8,7 +8,7 @@ from bingo.symbolic_regression.agraph.component_generator \
     import ComponentGenerator
 
 try:
-    from bingocpp.build import bingocpp as bingocpp
+    from bingocpp.build import symbolic_regression as bingocpp
 except ImportError:
     bingocpp = None
 

--- a/tests/agraph/test_agraph.py
+++ b/tests/agraph/test_agraph.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from bingo.symbolic_regression.agraph import agraph, backend as py_backend
 try:
-    from bingocpp.build import bingocpp as bingocpp
+    from bingocpp.build import symbolic_regression as bingocpp
     cpp_agraph = bingocpp.AGraph()
     CPP_LOADED = True
 except ImportError:

--- a/tests/agraph/test_agraph_backend.py
+++ b/tests/agraph/test_agraph_backend.py
@@ -8,7 +8,7 @@ import numpy as np
 from bingo.symbolic_regression.agraph import backend as PythonBackend
 
 try:
-    from bingocpp.build import bingocpp as CppBackend
+    from bingocpp.build import symbolic_regression as CppBackend
     CPP_LOADED = True
 except ImportError:
     CppBackend = None

--- a/tests/performance_benchmarking/benchmark_data.py
+++ b/tests/performance_benchmarking/benchmark_data.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from bingo.symbolic_regression.agraph \
     import agraph as agraph_module, backend as pyBackend
-from bingocpp.build import bingocpp as cppBackend
 from bingo.symbolic_regression.agraph.generator import AGraphGenerator
 from bingo.symbolic_regression.agraph.component_generator \
     import ComponentGenerator
@@ -14,7 +13,7 @@ from bingo.symbolic_regression.implicit_regression \
     import ImplicitRegression, ImplicitTrainingData, calculate_partials
 from bingo.symbolic_regression.explicit_regression \
     import ExplicitRegression, ExplicitTrainingData
-from bingocpp.build import bingocpp
+from bingocpp.build import symbolic_regression as bingocpp
 
 LOG_WIDTH = 78
 NUM_AGRAPHS_INDVS = 100

--- a/tests/performance_benchmarking/continous_local_opt_benchmarks.py
+++ b/tests/performance_benchmarking/continous_local_opt_benchmarks.py
@@ -6,7 +6,7 @@ from bingo.symbolic_regression.agraph \
     import agraph as agraph_module, backend as pyBackend
 from bingo.local_optimizers.continuous_local_opt \
     import ContinuousLocalOptimization
-from bingocpp.build import bingocpp as cppBackend
+from bingocpp.build import symbolic_regression as cppBackend
 
 from benchmark_data import StatsPrinter, \
                            generate_random_individuals, \

--- a/tests/performance_benchmarking/evaluation_benchmark.py
+++ b/tests/performance_benchmarking/evaluation_benchmark.py
@@ -2,7 +2,7 @@ import timeit
 
 from bingo.symbolic_regression.agraph \
     import agraph as agraph_module, backend as pyBackend
-from bingocpp.build import bingocpp as cppBackend
+from bingocpp.build import symbolic_regression as cppBackend
 
 import benchmark_data as benchmark_data
 from benchmark_data import TEST_AGRAPHS, TEST_X, EVAL_TIMING_NUMBER, \

--- a/tests/performance_benchmarking/fitness_benchmark.py
+++ b/tests/performance_benchmarking/fitness_benchmark.py
@@ -2,7 +2,7 @@ import timeit
 
 from bingo.symbolic_regression.agraph \
     import agraph as agraph_module, backend as pyBackend
-from bingocpp.build import bingocpp as cppBackend
+from bingocpp.build import symbolic_regression as cppBackend
 
 import benchmark_data as benchmark_data
 from benchmark_data import TEST_AGRAPHS, \

--- a/tests/symbolic_regression/conftest.py
+++ b/tests/symbolic_regression/conftest.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from bingo.symbolic_regression.equation import Equation
 try:
-    from bingocpp.build import bingocpp as bingocpp
+    from bingocpp.build import symbolic_regression as bingocpp
     CppEquation = bingocpp.Equation
 except ImportError:
     bingocpp = None

--- a/tests/symbolic_regression/test_explicit_regression.py
+++ b/tests/symbolic_regression/test_explicit_regression.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from bingo.symbolic_regression.explicit_regression import ExplicitRegression, ExplicitTrainingData
 try:
-    from bingocpp.build import bingocpp as bingocpp
+    from bingocpp.build import symbolic_regression as bingocpp
 except ImportError:
     bingocpp = None
 

--- a/tests/symbolic_regression/test_implicit_regression.py
+++ b/tests/symbolic_regression/test_implicit_regression.py
@@ -9,7 +9,7 @@ from bingo.symbolic_regression.implicit_regression import ImplicitRegression, \
                                      ImplicitRegressionSchmidt, \
                                      ImplicitTrainingData
 try:
-    from bingocpp.build import bingocpp as bingocpp
+    from bingocpp.build import symbolic_regression as bingocpp
 except ImportError:
     bingocpp = None
 


### PR DESCRIPTION
This PR requires the new name convention for the pybind modules defined in bingocpp. This uses the init file import modules from the symbolic_regression package and will use the C++ bindings by default if they are built correctly. This requires the user to import only the necessary tools from the symbolic_regression directory and will not require them to know where the C++ modules are built and how to import them correctly.