### PR TITLE
Tolerance Changes for TNC Explicit Regression Integration Tests

### DIFF
--- a/tests/integration/test_clo_explicit_regression.py
+++ b/tests/integration/test_clo_explicit_regression.py
@@ -57,7 +57,7 @@ def training_data(explicit_training_data):
 
 
 @pytest.fixture
-def norm_individual(agraph_implementation):
+def norm_individual(agraph_implementation):  # (1.0)((X_0)(X_0)) + (1.0)(X_0)
     individual = agraph_implementation()
     individual.command_array = np.array([[CONSTANT, -1, -1],
                                          [VARIABLE, 0, 0],
@@ -72,7 +72,7 @@ def norm_individual(agraph_implementation):
 
 
 @pytest.fixture
-def opt_individual(agraph_implementation):
+def opt_individual(agraph_implementation):  # (2)((X_0)(X_0)) + (3)(X_0)
     individual = agraph_implementation()
     individual.command_array = np.array([[CONSTANT, -1, -1],
                                          [VARIABLE, 0, 0],
@@ -93,7 +93,11 @@ def test_explicit_regression_clo_linear_mae(explicit_regression, training_data, 
     fitness = explicit_regression(training_data=training_data, metric='mae')
     optimizer = ContinuousLocalOptimization(fitness, algorithm)
     optimizer(norm_individual)
-    assert fitness(norm_individual) == pytest.approx(fitness(opt_individual), abs=1e-5)
+
+    tolerance = 1e-5
+    if algorithm == "TNC":
+        tolerance = 1e-1
+    assert fitness(norm_individual) == pytest.approx(fitness(opt_individual), abs=tolerance)
 
 
 @pytest.mark.parametrize('algorithm', MINIMIZE_SET)
@@ -111,7 +115,11 @@ def test_explicit_regression_clo_linear_rmse(explicit_regression, training_data,
     fitness = explicit_regression(training_data=training_data, metric='rmse')
     optimizer = ContinuousLocalOptimization(fitness, algorithm)
     optimizer(norm_individual)
-    assert fitness(norm_individual) == pytest.approx(fitness(opt_individual), abs=1e-5)
+
+    tolerance = 1e-5
+    if algorithm == "TNC":
+        tolerance = 2e-1
+    assert fitness(norm_individual) == pytest.approx(fitness(opt_individual), abs=tolerance)
 
 
 @pytest.mark.parametrize('algorithm', ROOT_SET)


### PR DESCRIPTION
Loosened tolerances for explicit regression integration tests when using the TNC algorithm for minimization.