### PR TITLE
Addition of Parameter Initialization Bounds and Optimization Options to CLO and Forced Use of Python Simplification

### DIFF
--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -126,7 +126,9 @@ class ContinuousLocalOptimization(FitnessFunction):
         self._algorithm = algorithm
 
         self._param_init_bounds = [-10000, 10000]
-        self._optimization_options = dict()
+        self._optimization_options = {"method": self._algorithm,
+                                      "tol": 1e-6,
+                                      "options": {}}
 
     @property
     def training_data(self):
@@ -160,12 +162,13 @@ class ContinuousLocalOptimization(FitnessFunction):
 
     @property
     def optimization_options(self):
-        """Dictionary of algorithm-specific options for clo"""
+        """Dictionary of options for clo
+        e.g. {"tol": 1e-8, "options": {"maxiter": 1000}}"""
         return self._optimization_options
 
     @optimization_options.setter
     def optimization_options(self, value):
-        self._optimization_options = value
+        self._optimization_options.update(value)
 
     def __call__(self, individual):
         """Evaluates the fitness of the individual. Provides local optimization
@@ -222,15 +225,11 @@ class ContinuousLocalOptimization(FitnessFunction):
                         sub_routine, params,
                         args=(individual, ),
                         jac=lambda x, indv: self._fitness_function.get_fitness_vector_and_jacobian(indv)[1],  # pylint: disable=line-too-long
-                        method=self._algorithm,
-                        tol=1e-6,
-                        options=self._optimization_options)
+                        **self._optimization_options)
             else:
                 optimize_result = optimize.root(sub_routine, params,
                                                 args=(individual),
-                                                method=self._algorithm,
-                                                tol=1e-6,
-                                                options=self._optimization_options)  # pylint: disable=line-too-long
+                                                **self._optimization_options)
         else:
             if isinstance(self._fitness_function, GradientMixin) \
                     and self._algorithm in JACOBIAN_SET:
@@ -238,15 +237,11 @@ class ContinuousLocalOptimization(FitnessFunction):
                         sub_routine, params,
                         args=(individual, ),
                         jac=lambda x, indv: self._fitness_function.get_fitness_and_gradient(indv)[1],  # pylint: disable=line-too-long
-                        method=self._algorithm,
-                        tol=1e-6,
-                        options=self._optimization_options)
+                        **self._optimization_options)
             else:
                 optimize_result = optimize.minimize(sub_routine, params,
                                                     args=(individual, ),
-                                                    method=self._algorithm,
-                                                    tol=1e-6,
-                                                    options=self._optimization_options)  # pylint: disable=line-too-long
+                                                    **self._optimization_options)
         return optimize_result.x
 
     def _evaluate_fitness(self, individual):

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -110,6 +110,14 @@ class ContinuousLocalOptimization(FitnessFunction):
         fitness function
     training_data :
         (Optional) data that can be used in the wrapped fitness function
+    param_init_bounds : iterable
+        (Optional) Bounds that are used to initialize clo params,
+           should be formatted as an iterable [low, high)
+           where low will be included in the initialization range and
+           high will be excluded
+    optimization_options : dict
+        (Optional) Dictionary of options for clo
+        e.g. {"tol": 1e-8, "options": {"maxiter": 1000}}
 
     Raises
     ------
@@ -118,7 +126,6 @@ class ContinuousLocalOptimization(FitnessFunction):
     TypeError :
         `fitness_function` must Be a valid `FitnessFunction` for the specified
         algorithm
-    # TODO need documentation of param init bounds and optimization options
     """
     def __init__(self, fitness_function, algorithm='Nelder-Mead',
                  param_init_bounds=None, optimization_options=None):
@@ -157,10 +164,7 @@ class ContinuousLocalOptimization(FitnessFunction):
 
     @property
     def param_init_bounds(self):
-        """Iterable: bounds that we use to initialize clo params,
-           should be formatted as an iterable [low, high]
-           where low will be included in the initialization range and
-           high will be excluded"""
+        """[low, high) bounds used to initialize clo params"""
         return self._param_init_bounds
 
     @param_init_bounds.setter
@@ -169,8 +173,7 @@ class ContinuousLocalOptimization(FitnessFunction):
 
     @property
     def optimization_options(self):
-        """Dictionary of options for clo
-        e.g. {"tol": 1e-8, "options": {"maxiter": 1000}}"""
+        """Continuous local optimization options (e.g. tolerance)"""
         return self._optimization_options
 
     @optimization_options.setter

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -148,7 +148,7 @@ class ContinuousLocalOptimization(FitnessFunction):
 
     @property
     def param_init_bounds(self):
-        """Iterable: bounds that we use to to initialize clo params
+        """Iterable: bounds that we use to initialize clo params,
            should be formatted as an iterable [low, high]
            where low will be included in the initialization range and
            high will be excluded"""

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -118,15 +118,24 @@ class ContinuousLocalOptimization(FitnessFunction):
     TypeError :
         `fitness_function` must Be a valid `FitnessFunction` for the specified
         algorithm
+    # TODO need documentation of param init bounds and optimization options
     """
-    def __init__(self, fitness_function, algorithm='Nelder-Mead'):
+    def __init__(self, fitness_function, algorithm='Nelder-Mead',
+                 param_init_bounds=None, optimization_options=None):
         self._check_algorithm_is_valid(algorithm)
         self._check_root_alg_returns_vector(fitness_function, algorithm)
         self._fitness_function = fitness_function
         self._algorithm = algorithm
 
-        self._param_init_bounds = [-10000, 10000]
-        self._optimization_options = {"tol": 1e-6}
+        if param_init_bounds is None:
+            self.param_init_bounds = [-10000, 10000]
+        else:
+            self.param_init_bounds = param_init_bounds
+
+        if optimization_options is None:
+            self.optimization_options = {"tol": 1e-6}
+        else:
+            self.optimization_options = optimization_options
 
     @property
     def training_data(self):
@@ -166,6 +175,7 @@ class ContinuousLocalOptimization(FitnessFunction):
 
     @optimization_options.setter
     def optimization_options(self, value):
+        self._optimization_options = {"tol": 1e-6}
         self._optimization_options.update(value)
 
     def __call__(self, individual):

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -202,7 +202,7 @@ class ContinuousLocalOptimization(FitnessFunction):
 
     def _optimize_params(self, individual):
         num_params = individual.get_number_local_optimization_params()
-        c_0 = np.random.uniform(self._param_init_bounds, num_params)
+        c_0 = np.random.uniform(*self._param_init_bounds, num_params)
         params = self._run_algorithm_for_optimization(
             self._sub_routine_for_fit_function, individual, c_0)
         individual.set_local_optimization_params(params)

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -128,7 +128,7 @@ class ContinuousLocalOptimization(FitnessFunction):
         algorithm
     """
     def __init__(self, fitness_function, algorithm='Nelder-Mead',
-                 param_init_bounds=None, optimization_options=None):
+                 param_init_bounds=None, **optimization_options_kwargs):
         self._check_algorithm_is_valid(algorithm)
         self._check_root_alg_returns_vector(fitness_function, algorithm)
         self._fitness_function = fitness_function
@@ -139,10 +139,8 @@ class ContinuousLocalOptimization(FitnessFunction):
         else:
             self.param_init_bounds = param_init_bounds
 
-        if optimization_options is None:
-            self.optimization_options = {"tol": 1e-6}
-        else:
-            self.optimization_options = optimization_options
+        self.optimization_options = optimization_options_kwargs  # default case
+        # handled in setter
 
     @property
     def training_data(self):
@@ -179,7 +177,7 @@ class ContinuousLocalOptimization(FitnessFunction):
     @optimization_options.setter
     def optimization_options(self, value):
         self._optimization_options = {"tol": 1e-6}
-        self._optimization_options.update(value)
+        self._optimization_options.update(**value)
 
     def __call__(self, individual):
         """Evaluates the fitness of the individual. Provides local optimization

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -126,9 +126,7 @@ class ContinuousLocalOptimization(FitnessFunction):
         self._algorithm = algorithm
 
         self._param_init_bounds = [-10000, 10000]
-        self._optimization_options = {"method": self._algorithm,
-                                      "tol": 1e-6,
-                                      "options": {}}
+        self._optimization_options = {"tol": 1e-6}
 
     @property
     def training_data(self):
@@ -225,10 +223,12 @@ class ContinuousLocalOptimization(FitnessFunction):
                         sub_routine, params,
                         args=(individual, ),
                         jac=lambda x, indv: self._fitness_function.get_fitness_vector_and_jacobian(indv)[1],  # pylint: disable=line-too-long
+                        method=self._algorithm,
                         **self._optimization_options)
             else:
                 optimize_result = optimize.root(sub_routine, params,
                                                 args=(individual),
+                                                method=self._algorithm,
                                                 **self._optimization_options)
         else:
             if isinstance(self._fitness_function, GradientMixin) \
@@ -237,10 +237,12 @@ class ContinuousLocalOptimization(FitnessFunction):
                         sub_routine, params,
                         args=(individual, ),
                         jac=lambda x, indv: self._fitness_function.get_fitness_and_gradient(indv)[1],  # pylint: disable=line-too-long
+                        method=self._algorithm,
                         **self._optimization_options)
             else:
                 optimize_result = optimize.minimize(sub_routine, params,
                                                     args=(individual, ),
+                                                    method=self._algorithm,
                                                     **self._optimization_options)  # pylint: disable=line-too-long
         return optimize_result.x
 

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -115,9 +115,11 @@ class ContinuousLocalOptimization(FitnessFunction):
            should be formatted as an iterable [low, high)
            where low will be included in the initialization range and
            high will be excluded
-    optimization_options : dict
-        (Optional) Dictionary of options for clo
-        e.g. {"tol": 1e-8, "options": {"maxiter": 1000}}
+    optimization_options_kwargs :
+        (Optional) Keyword arguments for clo options
+        e.g. (..., tol=1e-8, options={"maxiter": 1000})
+            alternatively you can also do
+            (..., **{"tol": 1e-8, "options": {"maxiter": 1000}})
 
     Raises
     ------

--- a/bingo/local_optimizers/continuous_local_opt.py
+++ b/bingo/local_optimizers/continuous_local_opt.py
@@ -241,7 +241,7 @@ class ContinuousLocalOptimization(FitnessFunction):
             else:
                 optimize_result = optimize.minimize(sub_routine, params,
                                                     args=(individual, ),
-                                                    **self._optimization_options)
+                                                    **self._optimization_options)  # pylint: disable=line-too-long
         return optimize_result.x
 
     def _evaluate_fitness(self, individual):

--- a/bingo/symbolic_regression/agraph/agraph.py
+++ b/bingo/symbolic_regression/agraph/agraph.py
@@ -64,7 +64,7 @@ except ImportError:
 
 LOGGER = logging.getLogger(__name__)
 
-using_python_simplification = False
+USING_PYTHON_SIMPLIFICATION = False
 
 
 def force_use_of_python_backends():
@@ -77,7 +77,6 @@ def force_use_of_python_backends():
     from .simplification_backend import simplification_backend
 
 
-# TODO test and potentially merge with force_use_of_python_backends()
 def force_use_of_python_simplification():
     """When c++ simplification is available, this can be used to force the use
     of python simplification"""
@@ -86,8 +85,8 @@ def force_use_of_python_simplification():
     global simplification_backend
     from .simplification_backend import simplification_backend
 
-    global using_python_simplification
-    using_python_simplification = True
+    global USING_PYTHON_SIMPLIFICATION
+    USING_PYTHON_SIMPLIFICATION = True
 
 
 class AGraph(Equation, continuous_local_opt.ChromosomeInterface):
@@ -118,7 +117,7 @@ class AGraph(Equation, continuous_local_opt.ChromosomeInterface):
         self._modified = False
         self._use_simplification = use_simplification
 
-        if use_simplification and not using_python_simplification:
+        if use_simplification and not USING_PYTHON_SIMPLIFICATION:
             force_use_of_python_simplification()
 
     @property

--- a/bingo/symbolic_regression/agraph/agraph.py
+++ b/bingo/symbolic_regression/agraph/agraph.py
@@ -64,6 +64,8 @@ except ImportError:
 
 LOGGER = logging.getLogger(__name__)
 
+using_python_simplification = False
+
 
 def force_use_of_python_backends():
     """When c++ backends are available, this can be used to force the use of
@@ -73,6 +75,19 @@ def force_use_of_python_backends():
     global evaluation_backend, simplification_backend
     from .evaluation_backend import evaluation_backend
     from .simplification_backend import simplification_backend
+
+
+# TODO test and potentially merge with force_use_of_python_backends()
+def force_use_of_python_simplification():
+    """When c++ simplification is available, this can be used to force the use
+    of python simplification"""
+    # pylint: disable=redefined-outer-name, global-statement, invalid-name
+    # pylint: disable=import-outside-toplevel
+    global simplification_backend
+    from .simplification_backend import simplification_backend
+
+    global using_python_simplification
+    using_python_simplification = True
 
 
 class AGraph(Equation, continuous_local_opt.ChromosomeInterface):
@@ -102,6 +117,9 @@ class AGraph(Equation, continuous_local_opt.ChromosomeInterface):
         self._needs_opt = False
         self._modified = False
         self._use_simplification = use_simplification
+
+        if use_simplification and not using_python_simplification:
+            force_use_of_python_simplification()
 
     @property
     def engine(self):

--- a/bingo/symbolic_regression/agraph/generator.py
+++ b/bingo/symbolic_regression/agraph/generator.py
@@ -12,6 +12,7 @@ except (ImportError, KeyError, ModuleNotFoundError) as e:
     from .agraph import AGraph
     BINGOCPP = False
 from .agraph import AGraph as pyAGraph
+from .agraph import force_use_of_python_simplification
 from ...chromosomes.generator import Generator
 from ...util.argument_validation import argument_validation
 
@@ -36,6 +37,9 @@ class AGraphGenerator(Generator):
             self._backend_generator_function = self._python_generator_function
         else:
             self._backend_generator_function = self._generator_function
+
+        if use_simplification:
+            force_use_of_python_simplification()
 
     def __call__(self):
         """Generates random agraph individual.

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -79,7 +79,10 @@ def test_can_set_param_bounds_and_clo_options(mocker):
 def test_init_param_bounds_and_clo_options(mocker):
     mocked_fitness_function = \
         mocker.Mock(side_effect=lambda individual: individual.param)
-    clo = ContinuousLocalOptimization(mocked_fitness_function, param_init_bounds=[2, 4], optimization_options={"options": {"maxiter": 0}})
+    clo = ContinuousLocalOptimization(mocked_fitness_function,
+                                      param_init_bounds=[2, 4],
+                                      optimization_options={
+                                          "options": {"maxiter": 0}})
 
     assert clo.param_init_bounds == [2, 4]
     assert clo.optimization_options == {"tol": 1e-6, "options": {"maxiter": 0}}
@@ -87,8 +90,7 @@ def test_init_param_bounds_and_clo_options(mocker):
 
 @pytest.mark.parametrize("algorithm", ["Nelder-Mead", "lm"])
 # using Nelder-Mead and lm to test minimize and root respectively
-def test_set_param_bounds_and_clo_options_affect_clo_minimize(mocker,
-                                                              algorithm):
+def test_set_param_bounds_and_clo_options_affect_clo(mocker, algorithm):
 
     mocked_fitness_function = \
         mocker.Mock(side_effect=lambda individual: individual.param)
@@ -98,7 +100,7 @@ def test_set_param_bounds_and_clo_options_affect_clo_minimize(mocker,
                                             "xatol": 1e-8,
                                             "adaptive": False}}
 
-    def mocked_optimize(*args, **kwargs):
+    def mocked_optimize(*_, **kwargs):
         if kwargs.get("options", False) == opt_options["options"] and \
                 kwargs.get("tol", False) == opt_options["tol"]:
             return OptimizeResult(x=[1.0])

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -82,6 +82,7 @@ def test_init_param_bounds_and_clo_options(mocker):
     assert clo.optimization_options == {"tol": 1e-6, "options": {"maxiter": 0}}
 
 
+# TODO update to use mocked scipy minimize
 def test_set_param_bounds_and_clo_options_affect_clo(mocker):
     mocked_fitness_function = \
         mocker.Mock(side_effect=lambda individual: individual.param)

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -47,8 +47,9 @@ def test_invalid_algorithm(mocker):
                                     algorithm='Dwayne - The Rock - Johnson')
 
 
-def test_can_set_param_initialization_bounds_and_optimization_options(mocker):
-    mocked_fitness_function = mocker.Mock(side_effect=lambda individual: individual.param)
+def test_can_set_param_bounds_and_clo_options(mocker):
+    mocked_fitness_function = \
+        mocker.Mock(side_effect=lambda individual: individual.param)
     dummy_individual = DummyLocalOptIndividual()
     clo = ContinuousLocalOptimization(mocked_fitness_function)
 
@@ -67,10 +68,13 @@ def test_can_set_param_initialization_bounds_and_optimization_options(mocker):
 
 
 def test_can_set_algorithm_specific_options(mocker):
-    mocked_fitness_function = mocker.Mock(side_effect=lambda individual: individual.param)
+    mocked_fitness_function = \
+        mocker.Mock(side_effect=lambda individual: individual.param)
     dummy_individual = DummyLocalOptIndividual()
     clo = ContinuousLocalOptimization(mocked_fitness_function, "Nelder-Mead")
-    clo.optimization_options = {"options": {"fatol": 1e-8, "xatol": 1e-8, "adaptive": False}}
+    clo.optimization_options = {"options": {"fatol": 1e-8,
+                                            "xatol": 1e-8,
+                                            "adaptive": False}}
     clo(dummy_individual)
 
     assert dummy_individual.param <= 1e-8
@@ -133,7 +137,8 @@ class GradientFitnessFunction(GradientMixin, FitnessFunction):
 def test_optimize_params_minimize_with_gradient(mocker, algorithm):
     fitness_function = mocker.create_autospec(GradientFitnessFunction)
     fitness_function.side_effect = lambda individual: 1 + individual.param**2
-    fitness_function.get_fitness_and_gradient = lambda individual: (1 + individual.param**2, 2 * individual.param)
+    fitness_function.get_fitness_and_gradient = \
+        lambda individual: (1 + individual.param**2, 2 * individual.param)
 
     local_opt_fitness_function = ContinuousLocalOptimization(
         fitness_function, algorithm)
@@ -169,7 +174,8 @@ def test_optimize_params_root_without_jacobian(mocker, algorithm):
 def test_optimize_params_root_with_jacobian(mocker, algorithm):
     fitness_function = mocker.create_autospec(JacobianVectorFitnessFunction)
     fitness_function.evaluate_fitness_vector = lambda x: 1 + np.abs([x.param])
-    fitness_function.get_fitness_vector_and_jacobian = lambda x: (1 + np.abs([x.param]), np.sign([x.param]))
+    fitness_function.get_fitness_vector_and_jacobian = \
+        lambda x: (1 + np.abs([x.param]), np.sign([x.param]))
 
     local_opt_fitness_function = ContinuousLocalOptimization(
         fitness_function, algorithm)

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -53,17 +53,25 @@ def test_can_set_param_bounds_and_clo_options(mocker):
     dummy_individual = DummyLocalOptIndividual()
     clo = ContinuousLocalOptimization(mocked_fitness_function)
 
-    clo.param_init_bounds = [2, 4]
-    clo.optimization_options = {"options": {"maxiter": 0}}
-    clo(dummy_individual)
+    param_init_bounds = [2, 4]
+    clo.param_init_bounds = param_init_bounds
+    assert clo.param_init_bounds == param_init_bounds
 
+    opt_options = {"options": {"maxiter": 0}}
+    expected_options = {"tol": 1e-6}
+    expected_options.update(opt_options)
+    clo.optimization_options = opt_options
+    assert clo.optimization_options == expected_options
+
+    clo(dummy_individual)
     assert dummy_individual.param >= 2
     assert dummy_individual.param < 4
 
-    clo.optimization_options = {"tol": 1e-8,
-                                "options": {"maxiter": 1000}}
-    clo(dummy_individual)
+    opt_options = {"tol": 1e-8, "options": {"maxiter": 1000}}
+    clo.optimization_options = opt_options
+    assert clo.optimization_options == opt_options
 
+    clo(dummy_individual)
     assert dummy_individual.param <= 1e-8
 
 

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -47,6 +47,31 @@ def test_invalid_algorithm(mocker):
                                     algorithm='Dwayne - The Rock - Johnson')
 
 
+def test_can_set_param_initialization_bounds_and_optimization_options(mocker):
+    mocked_fitness_function = mocker.Mock(side_effect=lambda x: 0)
+
+    dummy_individual = DummyLocalOptIndividual()
+    clo = ContinuousLocalOptimization(mocked_fitness_function)
+
+    assert clo.param_init_bounds[0] == -10000
+    assert clo.param_init_bounds[1] == 10000
+    assert clo.optimization_options == dict()
+
+    new_bounds = [-1, 1]
+    new_options = {"maxiter": 0}
+    clo.param_init_bounds= new_bounds
+    clo.optimization_options = new_options
+
+    assert clo.param_init_bounds[0] == new_bounds[0]
+    assert clo.param_init_bounds[1] == new_bounds[1]
+    assert clo.optimization_options == new_options
+
+    clo(dummy_individual)
+
+    assert dummy_individual.param >= -1
+    assert dummy_individual.param < 1
+
+
 def test_get_eval_count_pass_through(mocker):
     fitness_function = mocker.Mock()
     fitness_function.eval_count = 123

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -79,13 +79,21 @@ def test_can_set_param_bounds_and_clo_options(mocker):
 def test_init_param_bounds_and_clo_options(mocker):
     mocked_fitness_function = \
         mocker.Mock(side_effect=lambda individual: individual.param)
+    opt_options = {"options": {"maxiter": 0}}
     clo = ContinuousLocalOptimization(mocked_fitness_function,
                                       param_init_bounds=[2, 4],
-                                      optimization_options={
-                                          "options": {"maxiter": 0}})
+                                      **opt_options)
 
     assert clo.param_init_bounds == [2, 4]
     assert clo.optimization_options == {"tol": 1e-6, "options": {"maxiter": 0}}
+
+    clo = ContinuousLocalOptimization(mocked_fitness_function,
+                                      param_init_bounds=[2, 4],
+                                      tol=1e-8,
+                                      options={"maxiter": 10})
+
+    assert clo.param_init_bounds == [2, 4]
+    assert clo.optimization_options == {"tol": 1e-8, "options": {"maxiter": 10}}
 
 
 @pytest.mark.parametrize("algorithm", ["Nelder-Mead", "lm"])

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -91,7 +91,6 @@ def test_init_param_bounds_and_clo_options(mocker):
 @pytest.mark.parametrize("algorithm", ["Nelder-Mead", "lm"])
 # using Nelder-Mead and lm to test minimize and root respectively
 def test_set_param_bounds_and_clo_options_affect_clo(mocker, algorithm):
-
     mocked_fitness_function = \
         mocker.Mock(side_effect=lambda individual: individual.param)
 

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -48,28 +48,32 @@ def test_invalid_algorithm(mocker):
 
 
 def test_can_set_param_initialization_bounds_and_optimization_options(mocker):
-    mocked_fitness_function = mocker.Mock(side_effect=lambda x: 0)
-
+    mocked_fitness_function = mocker.Mock(side_effect=lambda individual: individual.param)
     dummy_individual = DummyLocalOptIndividual()
     clo = ContinuousLocalOptimization(mocked_fitness_function)
 
-    assert clo.param_init_bounds[0] == -10000
-    assert clo.param_init_bounds[1] == 10000
-    assert clo.optimization_options == dict()
-
-    new_bounds = [-1, 1]
-    new_options = {"maxiter": 0}
-    clo.param_init_bounds= new_bounds
-    clo.optimization_options = new_options
-
-    assert clo.param_init_bounds[0] == new_bounds[0]
-    assert clo.param_init_bounds[1] == new_bounds[1]
-    assert clo.optimization_options == new_options
-
+    clo.param_init_bounds = [2, 4]
+    clo.optimization_options = {"options": {"maxiter": 0}}
     clo(dummy_individual)
 
-    assert dummy_individual.param >= -1
-    assert dummy_individual.param < 1
+    assert dummy_individual.param >= 2
+    assert dummy_individual.param < 4
+
+    clo.optimization_options = {"tol": 1e-8,
+                                "options": {"maxiter": 1000}}
+    clo(dummy_individual)
+
+    assert dummy_individual.param <= 1e-8
+
+
+def test_can_set_algorithm_specific_options(mocker):
+    mocked_fitness_function = mocker.Mock(side_effect=lambda individual: individual.param)
+    dummy_individual = DummyLocalOptIndividual()
+    clo = ContinuousLocalOptimization(mocked_fitness_function, "Nelder-Mead")
+    clo.optimization_options = {"options": {"fatol": 1e-8, "xatol": 1e-8, "adaptive": False}}
+    clo(dummy_individual)
+
+    assert dummy_individual.param <= 1e-8
 
 
 def test_get_eval_count_pass_through(mocker):

--- a/tests/unit/local_optimizers/test_continuous_local_optimization.py
+++ b/tests/unit/local_optimizers/test_continuous_local_optimization.py
@@ -50,6 +50,41 @@ def test_invalid_algorithm(mocker):
 def test_can_set_param_bounds_and_clo_options(mocker):
     mocked_fitness_function = \
         mocker.Mock(side_effect=lambda individual: individual.param)
+    clo = ContinuousLocalOptimization(mocked_fitness_function)
+
+    assert clo.param_init_bounds == [-10000, 10000]
+    assert clo.optimization_options == {"tol": 1e-6}
+
+    param_init_bounds = [2, 4]
+    opt_options = {"options": {"maxiter": 0}}
+
+    expected_options = {"tol": 1e-6}
+    expected_options.update(opt_options)
+
+    clo.param_init_bounds = param_init_bounds
+    clo.optimization_options = opt_options
+
+    assert clo.param_init_bounds == param_init_bounds
+    assert clo.optimization_options == expected_options
+
+    opt_options = {"tol": 1e-8}
+    expected_options = opt_options
+    clo.optimization_options = opt_options
+    assert clo.optimization_options == expected_options
+
+
+def test_init_param_bounds_and_clo_options(mocker):
+    mocked_fitness_function = \
+        mocker.Mock(side_effect=lambda individual: individual.param)
+    clo = ContinuousLocalOptimization(mocked_fitness_function, param_init_bounds=[2, 4], optimization_options={"options": {"maxiter": 0}})
+
+    assert clo.param_init_bounds == [2, 4]
+    assert clo.optimization_options == {"tol": 1e-6, "options": {"maxiter": 0}}
+
+
+def test_set_param_bounds_and_clo_options_affect_clo(mocker):
+    mocked_fitness_function = \
+        mocker.Mock(side_effect=lambda individual: individual.param)
     dummy_individual = DummyLocalOptIndividual()
     clo = ContinuousLocalOptimization(mocked_fitness_function)
 


### PR DESCRIPTION
I added customizable param_init_bounds and optimization_options properties to the ContinuousLocalOptimization class. I think we spoke about making these options as class properties but let me know if you have another preferred way of implementing this.