### PR TITLE
conda source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ Then make sure you have the requirements necessary to use Bingo:
 pip install -r requirements.txt
 ```
 
+This can alternatively be done using conda:
+
+```sh
+conda create --name bingo --channel conda-forge --file requirements.txt
+conda activate bingo
+```
+
 (Optional) Then build the c++ performance library BingoCpp:
 
 ```sh
@@ -157,6 +164,18 @@ the installation process worked properly:
 
 ```sh
 pytest tests
+```
+
+You can also add Bingo to your Python path. Add the following to your `.bashrc` (or some equivalent) file:
+
+```sh
+export PYTHONPATH="$PYTHONPATH:/path/to/bingo/"
+```
+
+You can then import Bingo/BingoCpp when running python in any directory:
+
+```sh
+python -c 'import bingo; import bingocpp'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For those looking to develop their own features in Bingo.
 
 First clone the repo and move into the directory:
 
-```console
+```sh
 git clone --recurse-submodules https://github.com/nasa/bingo.git
 cd bingo
 ```


### PR DESCRIPTION
I usually install Bingo in a conda env, maybe others are interested as well. I added the instructions to the README. As well as a detail about adding Bingo to your PYTHONPATH to use it outside of the cloned repo.

Bingo could also be installed this way by doing `python setup.py install` at the end, where `python` is the conda env's python, but it doesn't work out (probably similar issues as the `pip install bingo-nasa`).