### PR TITLE
Deep copy of full fitness function in fitness predictor fitness function

### DIFF
--- a/bingo/evolutionary_optimizers/fitness_predictor.py
+++ b/bingo/evolutionary_optimizers/fitness_predictor.py
@@ -12,7 +12,7 @@ Check out the works of the works of Schmidt and Lipson for more details:
 e.g., "Coevolution of Fitness Predictors" (2008) .
 """
 import logging
-from copy import copy
+from copy import deepcopy
 import numpy as np
 from ..util.argument_validation import argument_validation
 from ..evaluation.fitness_function import FitnessFunction
@@ -45,7 +45,7 @@ class FitnessPredictorFitnessFunction(FitnessFunction):
         super().__init__(training_data)
         self._next_trainer_to_update = 0
         self.point_eval_count = 0
-        self._fitness_function = copy(full_fitness_function)
+        self._fitness_function = deepcopy(full_fitness_function)
         self._trainers, self._true_fitness_for_trainers = \
             self._make_initial_trainer_population(potential_trainers,
                                                   num_trainers)

--- a/tests/unit/evolutionary_optimizers/test_fitness_predictor.py
+++ b/tests/unit/evolutionary_optimizers/test_fitness_predictor.py
@@ -69,8 +69,8 @@ def test_deep_copy_of_full_fitness_fn(mocked_training_data,
                                                        mocked_fitness_function,
                                                        mocked_population,
                                                        num_trainers=5)
-    assert predictor_fit_fn._fitness_function != mocked_fitness_function
-    assert predictor_fit_fn._fitness_function.training_data != \
+    assert predictor_fit_fn._fitness_function is not mocked_fitness_function
+    assert predictor_fit_fn._fitness_function.training_data is not \
            mocked_fitness_function.training_data
 
 

--- a/tests/unit/evolutionary_optimizers/test_fitness_predictor.py
+++ b/tests/unit/evolutionary_optimizers/test_fitness_predictor.py
@@ -62,6 +62,18 @@ def test_raises_error_not_enough_valid_trainers(mocker, mocked_training_data,
                                             num_trainers=5)
 
 
+def test_deep_copy_of_full_fitness_fn(mocked_training_data,
+                                      mocked_fitness_function,
+                                      mocked_population):
+    predictor_fit_fn = FitnessPredictorFitnessFunction(mocked_training_data,
+                                                       mocked_fitness_function,
+                                                       mocked_population,
+                                                       num_trainers=5)
+    assert predictor_fit_fn._fitness_function != mocked_fitness_function
+    assert predictor_fit_fn._fitness_function.training_data != \
+           mocked_fitness_function.training_data
+
+
 def test_adding_trainers_to_predictor_fitness_function(mocker,
                                                        predictor_fit_func):
     for i in range(10):


### PR DESCRIPTION
If I remember correctly, this fixes a bug where the fitness predictor fitness function keeps the full dataset rather than its subset. I wasn't in the meeting when you guys found this bug, so could you fill me in on why this solution works? If we end up changing the training data on the fitness function, I don't see why the distinction between copy and deepcopy would matter.