### PR TITLE
feat: format elapsed time as H:M:S in logs

### DIFF
--- a/bingo/evolutionary_optimizers/evolutionary_optimizer.py
+++ b/bingo/evolutionary_optimizers/evolutionary_optimizer.py
@@ -20,6 +20,37 @@ LOGGER = logging.getLogger(__name__)
 STATS_LOGGER = logging.LoggerAdapter(LOGGER, extra={"stats": True})
 DIAGNOSTICS_LOGGER = logging.LoggerAdapter(LOGGER, extra={"diagnostics": True})
 
+
+def _format_elapsed_time(elapsed_time):
+    """Format elapsed time as H:M:S with progressive visibility.
+
+    Parameters
+    ----------
+    elapsed_time : timedelta
+        The elapsed time to format
+
+    Returns
+    -------
+    str
+        Formatted time string where:
+        - Hours and minutes only appear when nonzero
+        - Seconds are floating point with 2 decimals
+        - When M or H is nonzero, S is 0-padded to 2 digits
+        - When H is nonzero, M is also 0-padded to 2 digits
+    """
+    total_seconds = elapsed_time.total_seconds()
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    hours = int(hours)
+    minutes = int(minutes)
+
+    if hours > 0:
+        return f"{hours}:{minutes:02d}:{seconds:05.2f}"
+    elif minutes > 0:
+        return f"{minutes}:{seconds:05.2f}"
+    else:
+        return f"{seconds:.2f}"
+
 OptimizeResult = namedtuple(
     "OptimizeResult",
     [
@@ -207,7 +238,7 @@ class EvolutionaryOptimizer(metaclass=ABCMeta):
             test_fitness = self._test_function(self.get_best_individual())
         log_string = f"Generation: {self.generational_age} \t "
         elapsed_time = datetime.now() - start_time
-        log_string += f"Elapsed time: {elapsed_time.total_seconds():f} \t "
+        log_string += f"Elapsed time: {_format_elapsed_time(elapsed_time)} \t "
         log_string += f"Best training fitness: {self._best_fitness:e} \t "
         if test_fitness is not None:
             log_string += f"Test fitness: {test_fitness:e} \t "

--- a/tests/unit/evolutionary_optimizers/test_evolutionary_optimizer.py
+++ b/tests/unit/evolutionary_optimizers/test_evolutionary_optimizer.py
@@ -7,9 +7,11 @@ from collections import namedtuple
 from time import sleep, time
 import numpy as np
 
+from datetime import timedelta
 from bingo.evolutionary_optimizers.evolutionary_optimizer import (
     EvolutionaryOptimizer,
     load_evolutionary_optimizer_from_file,
+    _format_elapsed_time,
 )
 from bingo.stats.hall_of_fame import HallOfFame
 
@@ -351,3 +353,28 @@ def test_strict_time_limit():
 
     assert elapsed_time < max_time
     assert optim_result.status == 5
+
+
+# Tests for _format_elapsed_time function
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        # Seconds only
+        (0.0, "0.00"),
+        (5.5, "5.50"),
+        (59.99, "59.99"),
+        # Minutes and seconds
+        (60.0, "1:00.00"),
+        (63.65, "1:03.65"),
+        (125.5, "2:05.50"),
+        (599.99, "9:59.99"),
+        # Hours, minutes, and seconds
+        (3600.0, "1:00:00.00"),
+        (3661.5, "1:01:01.50"),
+        (7325.25, "2:02:05.25"),
+        (36000.0, "10:00:00.00"),
+    ],
+)
+def test_format_elapsed_time(seconds, expected):
+    elapsed = timedelta(seconds=seconds)
+    assert _format_elapsed_time(elapsed) == expected


### PR DESCRIPTION
## Summary

Improve the readability of elapsed time in log output by formatting it as `H:M:S` instead of raw float seconds.

Fixes #80

## Before
```
Generation: 120 	 Elapsed time: 63.651301 	 Best training fitness: 5.864081e-03
```

## After
```
Generation: 120 	 Elapsed time: 1:03.65 	 Best training fitness: 5.864081e-03
```

## Format Rules

As specified in the issue:
- Shows only seconds (with 2 decimals) when under 1 minute: `63.65`
- Shows `M:SS.ss` when 1+ minutes but under 1 hour: `1:03.65`
- Shows `H:MM:SS.ss` for 1+ hours: `1:01:03.65`
- Minutes are 0-padded when hours are present
- Seconds are 0-padded to 2 digits when minutes or hours are present

## Note

Time values in CSV output logs (stats and diagnostics) remain as float seconds for compatibility with data processing tools, as mentioned in the issue.

## Testing

Added comprehensive unit tests covering:
- Seconds only (0-60 seconds)
- Minutes and seconds (1-60 minutes)
- Hours, minutes and seconds (1+ hours)

All tests pass.