### PR TITLE
Add descriptive ValueError when no operators are added to ComponentGenerator

### DIFF
--- a/bingo/expressions/agraph/component_generator.py
+++ b/bingo/expressions/agraph/component_generator.py
@@ -197,7 +197,17 @@ class ComponentGenerator:
         Returns
         -------
         int
+
+        Raises
+        ------
+        ValueError
+            If no operators have been added via :meth:`add_operator`.
         """
+        if not self._operator_pmf.items:
+            raise ValueError(
+                "No operators have been added to this ComponentGenerator. "
+                "Call add_operator() before generating graphs."
+            )
         return self._operator_pmf.draw_sample()
 
     def random_operator_parameter(self, stack_location):

--- a/tests/unit/expressions/agraph/test_component_generator.py
+++ b/tests/unit/expressions/agraph/test_component_generator.py
@@ -245,7 +245,7 @@ class TestNoOperatorsError:
             gen.random_operator_command(5)
 
     def test_generator_call_raises_without_operators(self):
-        """Replicates the exact usage from the bug report."""
+        """Replicates the bug-report usage (with min_size bumped to ensure an operator is requested)."""
         from bingo.expressions.agraph.generator import AGraphGenerator
 
         rng = np.random.default_rng(seed=42)

--- a/tests/unit/expressions/agraph/test_component_generator.py
+++ b/tests/unit/expressions/agraph/test_component_generator.py
@@ -229,3 +229,34 @@ class TestCustomLoadStatements:
             cmd1 = gen.random_command(1)
             assert int(cmd0[0]) in TERMINAL_IDS
             assert int(cmd1[0]) in TERMINAL_IDS
+
+
+class TestNoOperatorsError:
+    """Descriptive error when no operators have been added (issue #90)."""
+
+    def test_random_operator_raises_without_operators(self):
+        gen = ComponentGenerator(input_x_dimension=2, random_state=0)
+        with pytest.raises(ValueError, match="No operators have been added"):
+            gen.random_operator()
+
+    def test_random_operator_command_raises_without_operators(self):
+        gen = ComponentGenerator(input_x_dimension=2, random_state=0)
+        with pytest.raises(ValueError, match="No operators have been added"):
+            gen.random_operator_command(5)
+
+    def test_generator_call_raises_without_operators(self):
+        """Replicates the exact usage from the bug report."""
+        from bingo.expressions.agraph.generator import AGraphGenerator
+
+        rng = np.random.default_rng(seed=42)
+        component_generator = ComponentGenerator(
+            input_x_dimension=2, random_state=rng
+        )
+        generator = AGraphGenerator(
+            min_size=3,
+            max_size=11,
+            component_generator=component_generator,
+            random_state=rng,
+        )
+        with pytest.raises(ValueError, match="No operators have been added"):
+            generator()


### PR DESCRIPTION
Fixes #90.

## Problem

When `ComponentGenerator` is used without calling `add_operator()`, `random_operator()` raises a cryptic `IndexError: list index out of range` from deep in `ProbabilityMassFunction.draw_sample()`. The error gives users no indication of what went wrong or how to fix it.

## Fix

Add a guard in `random_operator()` that checks if `_operator_pmf.items` is empty and raises a descriptive `ValueError` instead:

```
ValueError: No operators have been added to this ComponentGenerator. Call add_operator() before generating graphs.
```

Since `random_operator()` is the single choke point for all operator-drawing paths (direct calls, `random_operator_command()`, and `random_command()` → PMF → `random_operator_command()`), the guard catches all entry paths with one check.

## Tests

Added `TestNoOperatorsError` class with three tests:
- `test_random_operator_raises_without_operators` — direct call to `random_operator()`
- `test_random_operator_command_raises_without_operators` — via `random_operator_command()`
- `test_generator_call_raises_without_operators` — end-to-end replication via `AGraphGenerator.__call__`

All 31 tests in `test_component_generator.py` pass. The 2 pre-existing failures in `test_expression.py` (sklearn `__sklearn_tags__` compatibility) are unrelated to this change.